### PR TITLE
add overall debug flag to indicate debugging level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/sethvargo/go-password v0.1.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2

--- a/pkg/sendgrid/errors.go
+++ b/pkg/sendgrid/errors.go
@@ -1,0 +1,33 @@
+package sendgrid
+
+//AlreadyExistsError Error to indicate an API key already exists
+type AlreadyExistsError struct {
+	Message string
+}
+
+//Error String representation of error
+func (e *AlreadyExistsError) Error() string {
+	return e.Message
+}
+
+//IsAlreadyExistsError Compare check for AlreadyExistsError
+func IsAlreadyExistsError(err error) bool {
+	_, ok := err.(*AlreadyExistsError)
+	return ok
+}
+
+//NotExistError Error to indicate an API key does not exist
+type NotExistError struct {
+	Message string
+}
+
+//Error String representation of error
+func (e *NotExistError) Error() string {
+	return e.Message
+}
+
+//IsNotExistError Compare check for NotExistError
+func IsNotExistError(err error) bool {
+	_, ok := err.(*NotExistError)
+	return ok
+}

--- a/pkg/sendgrid/sendgrid_test.go
+++ b/pkg/sendgrid/sendgrid_test.go
@@ -399,7 +399,7 @@ func TestClient_Create(t *testing.T) {
 			fields: fields{
 				sendgridClient: newMockAPIClient(func(c *APIClientMock) {
 					c.GetSubUserByUsernameFunc = func(username string) (user *SubUser, e error) {
-						return nil, &smtpdetails.NotExistError{Message: ""}
+						return nil, &NotExistError{Message: ""}
 					}
 					c.GetAPIKeysForSubUserFunc = func(username string) (keys []*APIKey, e error) {
 						return []*APIKey{}, nil

--- a/pkg/sendgrid/sendgridapi.go
+++ b/pkg/sendgrid/sendgridapi.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/integr8ly/smtp-service/pkg/smtpdetails"
-
 	"github.com/pkg/errors"
 	"github.com/sendgrid/rest"
 	"github.com/sirupsen/logrus"
@@ -69,7 +67,7 @@ func (c *BackendAPIClient) GetAPIKeysForSubUser(username string) ([]*APIKey, err
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list api keys for user %s", username)
 	}
-	var apiKeysResp apiKeysListResponse
+	var apiKeysResp *apiKeysListResponse
 	if err := json.Unmarshal([]byte(listResp.Body), &apiKeysResp); err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal api keys response, content=%s", listResp.Body)
 	}
@@ -166,7 +164,7 @@ func (c *BackendAPIClient) GetSubUserByUsername(username string) (*SubUser, erro
 		return nil, errors.Wrapf(err, "failed to list sub users with username %s", username)
 	}
 	if len(subusers) != 1 {
-		return nil, &smtpdetails.NotExistError{Message: fmt.Sprintf("should be exactly one sub user with username %s, found %d", username, len(subusers))}
+		return nil, &NotExistError{Message: fmt.Sprintf("should be exactly one sub user with username %s, found %d", username, len(subusers))}
 	}
 	return subusers[0], nil
 }


### PR DESCRIPTION
currently there is no way to adjust the debug level of the cli
without recompilation of the cli.

this change adds a debug flag '--debug' or '-d' that allows the
verbosity of the output to be set.

by default, all debug messages should be written to stderr so that
stdout can be piped to the 'oc' tool if needed.

minor changes were also made to not use the smtpdetails errors in
the sendgrid api logic. this will allow sendgrid api logic to be
separated into a separate package in the future. resulting in a
package structure of:

'''
pkg/
  sendgrid/     - for rhmi-aware sendgrid logic
  sendgridapi/  - for independent sendgrid logic
  smtpdetails/  - for abstracted interfaces and structs
'''

this restructure does not take place in this commit.

verification:
- run './cli create rhmi_deleteme --debug=verbose'
- ensure debug logs are shown and are written to stderr
- run './cli create rhmi_deleteme'
- ensure there are no debug logs by default