### PR TITLE
add secret kind and version explicitly when converting

### DIFF
--- a/pkg/smtpdetails/smtpdetails.go
+++ b/pkg/smtpdetails/smtpdetails.go
@@ -27,6 +27,10 @@ type Client interface {
 //ConvertSMTPDetailsToSecret Format a standard set of SMTPDetails as a Kubernetes Secret
 func ConvertSMTPDetailsToSecret(smtpDetails *SMTPDetails, secretName string) *apiv1.Secret {
 	return &apiv1.Secret{
+		TypeMeta: v1.TypeMeta{
+			Kind:       SecretGVKKind,
+			APIVersion: SecretGVKVersion,
+		},
 		ObjectMeta: v1.ObjectMeta{
 			Name: secretName,
 		},

--- a/pkg/smtpdetails/smtpdetails_test.go
+++ b/pkg/smtpdetails/smtpdetails_test.go
@@ -47,6 +47,10 @@ func TestConvertSMTPDetailsToSecret(t *testing.T) {
 				secretName:  "testSec",
 			},
 			want: &apiv1.Secret{
+				TypeMeta: v1.TypeMeta{
+					Kind:       SecretGVKKind,
+					APIVersion: SecretGVKVersion,
+				},
 				ObjectMeta: v1.ObjectMeta{
 					Name: "testSec",
 				},

--- a/pkg/smtpdetails/strings.go
+++ b/pkg/smtpdetails/strings.go
@@ -13,4 +13,8 @@ const (
 	SecretKeyUsername = "username"
 	//SecretKeyPassword Default secret data key for SMTP auth password
 	SecretKeyPassword = "password"
+	//SecretGVKKind GVK Kind of an OpenShift/Kubernetes Secret
+	SecretGVKKind = "Secret"
+	//SecretGVKVersion GVK Version of an OpenShift/Kubernetes Secret
+	SecretGVKVersion = "v1"
 )


### PR DESCRIPTION
currently the kind and version in the type meta of the secret
output is not set. this means that the output of the 'create'
command is not a valid secret and cannot be piped into the
'oc create -f -' command. this is something the cli should be
able to do.

this commit updates the secret to ensure the kind and version are
set in the type metadata on the secret resource.

verification:
- authenticate with an openshift cluster using 'oc login ...'
- run './cli delete rhmi_deleteme' to cleanup an existing user
- run './cli create rhmi_deleteme | oc create -f -'
- run 'oc get secret rhmi-smtp'
- ensure a new secret is created in the openshift cluster