### PR TITLE
add goreleaser to push binaries on each tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: goreleaser
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,12 @@ _testmain.go
 *.test
 *.prof
 
-.idea
+## Builds
 cli
+
+## Goland
+.idea
+
+## Goreleaser
+dist/
+bin/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,23 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+builds:
+- main: ./cmd/cli/main.go
+  env:
+  - CGO_ENABLED=0
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ vendor/check: vendor/fix
 vendor/fix:
 	go mod tidy
 	go mod vendor
+
+.PHONY: setup/goreleaser
+setup/goreleaser:
+	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh

--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ To run unit tests, run:
 ```
 make test/unit
 ```
+
+## Releases
+
+New binaries for a release tag will be created by [GoReleaser](https://goreleaser.com/) automatically.
+
+To try out GoReleaser locally, it can be installed using `make setup/goreleaser`. 


### PR DESCRIPTION
currently, to make binaries for the smtp-service cli available
they must be manually built. this will eventually lead to human
error and inconsistencies in the release format.

this commit adds a github workflow that will be performed on each
tag of the repo that will run the goreleaser tool. this will build
and push binaries to github releases automatically.

verification:
- create a new tag
- ensure the release workflow starts on github
- ensure new binaries are pushed for the new tag