### PR TITLE
add prerequisite check for sendgrid api key on default client

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -39,7 +39,7 @@ func main() {
 	logger := logrus.WithField("service", "rhmi_sendgrid_cli")
 	smtpdetailsClient, err := sendgrid.NewDefaultClient(logger)
 	if err != nil {
-		logger.Fatalf("failed to create sendgrid details client")
+		logger.Fatalf("failed to create sendgrid details client: %v", err)
 		os.Exit(1)
 	}
 

--- a/pkg/sendgrid/sendgrid.go
+++ b/pkg/sendgrid/sendgrid.go
@@ -32,7 +32,11 @@ func NewDefaultClient(logger *logrus.Entry) (*Client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create default password generator")
 	}
-	sendgridRESTClient := NewBackendRESTClient(APIHost, os.Getenv(EnvAPIKey), logger)
+	sendgridAPIKeyEnv := os.Getenv(EnvAPIKey)
+	if sendgridAPIKeyEnv == "" {
+		return nil, errors.New("SENDGRID_API_KEY env var must be defined")
+	}
+	sendgridRESTClient := NewBackendRESTClient(APIHost, sendgridAPIKeyEnv, logger)
 	sendgridClient := NewBackendAPIClient(sendgridRESTClient, logger)
 	return NewClient(sendgridClient, DefaultAPIKeyScopes, passGen, logger.WithField(smtpdetails.LogFieldDetailProvider, ProviderName))
 }


### PR DESCRIPTION
when a default sendgrid wrapper client is created, the env var
SENDGRID_API_KEY is used as the value of the api key passed into
the client.

it is possible that this env var is not set.

this commit ensures a meaningful error message is returned when
the SENDGRID_API_KEY env var is not set.

verification:
- run 'make build/cli'
- run 'unset SENDGRID_API_KEY'
- run './cli'
- ensure the error printed out explains the issue correctly