### PR TITLE
refactor cli of the smtp-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ _testmain.go
 *.prof
 
 ## Builds
-cli
+/cli
 
 ## Goland
 .idea

--- a/cmd/cli/create.go
+++ b/cmd/cli/create.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -60,14 +45,5 @@ var createCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(createCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
 	createCmd.Flags().StringP("secret-name", "s", defaultOutputSecretName, "Name of the output secret")
 }

--- a/cmd/cli/create.go
+++ b/cmd/cli/create.go
@@ -1,0 +1,73 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/integr8ly/smtp-service/pkg/smtpdetails"
+	"github.com/spf13/cobra"
+)
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create [cluster id]",
+	Short: "create sendgrid sub user and api key associated with [cluster id]",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		smtpDetailsClient, err := setupSMTPDetailsClient(logger)
+		if err != nil {
+			exitError("failed to setup smtp details client", exitCodeErrUnknown)
+		}
+		smtpDetails, err := smtpDetailsClient.Create(args[0])
+		if err != nil {
+			if smtpdetails.IsAlreadyExistsError(err) {
+				exitError(fmt.Sprintf("api key for cluster %s already exists", args[0]), exitCodeErrKnown)
+			}
+			exitError(fmt.Sprintf("unknown error: %v", err), exitCodeErrUnknown)
+		}
+		logger.Debug("smtp details created successfully, converting to secret")
+		secretName, err := cmd.Flags().GetString("secret-name")
+		if err != nil {
+			exitError("failed to get secret name flag", exitCodeErrUnknown)
+		}
+		if secretName == "" {
+			logger.Infof("secret name is blank, using default name %s", defaultOutputSecretName)
+			secretName = defaultOutputSecretName
+		}
+		smtpSecret := smtpdetails.ConvertSMTPDetailsToSecret(smtpDetails, secretName)
+		smtpJSON, err := json.MarshalIndent(smtpSecret, "", "    ")
+		if err != nil {
+			exitError(fmt.Sprintf("error converting details to secret: %v", err), exitCodeErrUnknown)
+		}
+		exitSuccess(string(smtpJSON))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	createCmd.Flags().StringP("secret-name", "s", defaultOutputSecretName, "Name of the output secret")
+}

--- a/cmd/cli/delete.go
+++ b/cmd/cli/delete.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -44,14 +29,4 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(deleteCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deleteCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cli/delete.go
+++ b/cmd/cli/delete.go
@@ -1,0 +1,57 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+
+	"github.com/integr8ly/smtp-service/pkg/smtpdetails"
+	"github.com/spf13/cobra"
+)
+
+// deleteCmd represents the delete command
+var deleteCmd = &cobra.Command{
+	Use:   "delete [cluster id]",
+	Short: "delete sendgrid sub user and api key associated with [cluster id]",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		smtpDetailsClient, err := setupSMTPDetailsClient(logger)
+		if err != nil {
+			exitError("failed to setup smtp details client", exitCodeErrUnknown)
+		}
+		if err := smtpDetailsClient.Delete(args[0]); err != nil {
+			if smtpdetails.IsNotExistError(err) {
+				exitError(fmt.Sprintf("api key for cluster %s does not exist: %+v", args[0], err), exitCodeErrKnown)
+			}
+			exitError(fmt.Sprintf("failed to delete api key %v", err), exitCodeErrUnknown)
+		}
+		exitSuccess("api key deleted")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deleteCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deleteCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deleteCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/cli/get.go
+++ b/cmd/cli/get.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"fmt"
+
+	"github.com/integr8ly/smtp-service/pkg/smtpdetails"
+	"github.com/spf13/cobra"
+)
+
+// getCmd represents the get command
+var getCmd = &cobra.Command{
+	Use:   "get [cluster id]",
+	Short: "get sendgrid api key id associated with [cluster id]",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		smtpDetailsClient, err := setupSMTPDetailsClient(logger)
+		if err != nil {
+			exitError("failed to setup smtp details client", exitCodeErrUnknown)
+		}
+		smtpDetails, err := smtpDetailsClient.Get(args[0])
+		if err != nil {
+			if smtpdetails.IsNotExistError(err) {
+				exitError(fmt.Sprintf("api key for cluster %s not found", args[0]), exitCodeErrKnown)
+			}
+			exitError(fmt.Sprintf("unknown error: %v", err), exitCodeErrUnknown)
+		}
+		exitSuccess(smtpDetails.ID)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(getCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/cli/get.go
+++ b/cmd/cli/get.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -45,14 +30,4 @@ var getCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(getCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// getCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// getCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -71,14 +56,6 @@ func init() {
 			logger.Logger.SetLevel(logrus.DebugLevel)
 		}
 	})
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.main.yaml)")
-
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
 	rootCmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "Enable debug output to stderr")
 }
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,147 +1,49 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
-
-	"github.com/spf13/pflag"
-
-	"github.com/integr8ly/smtp-service/version"
-
-	"github.com/integr8ly/smtp-service/pkg/smtpdetails"
-
 	"github.com/integr8ly/smtp-service/pkg/sendgrid"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/spf13/cobra"
 )
 
 const (
-	defaultOutputSecretName = "rhmi-smtp"
+	defaultOutputSecretName = "redhat-rhmi-smtp"
 	exitCodeErrKnown        = 1
 	exitCodeErrUnknown      = 2
 )
 
-var (
-	flagDebug string
-)
+var flagDebug = false
+var logger = logrus.NewEntry(&logrus.Logger{
+	Out:          os.Stderr,
+	Formatter:    &logrus.TextFormatter{},
+	ReportCaller: false,
+	Level:        logrus.FatalLevel,
+})
 
-func init() {
-	pflag.StringVarP(&flagDebug, "debug", "d", "error", "--debug=[info|verbose|error]")
-}
-
-func main() {
-	pflag.Parse()
-
-	logrus.SetFormatter(&logrus.TextFormatter{})
-	logrus.SetLevel(getDebugLevelFromString(flagDebug))
-	logrus.SetOutput(os.Stderr)
-	logger := logrus.WithField("service", "rhmi_sendgrid_cli")
-
-	rootCmd := &cobra.Command{
-		Use:   "cli [sub command]",
-		Short: "commands for managing rhmi cluster api keys",
-	}
-
-	cmdCreate := &cobra.Command{
-		Use:   "create [cluster id]",
-		Short: "create sendgrid sub user and api key associated with [cluster id]",
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			smtpDetailsClient, err := setupSMTPDetailsClient(logger)
-			if err != nil {
-				exitError("failed to setup smtp details client", exitCodeErrUnknown)
-			}
-			smtpDetails, err := smtpDetailsClient.Create(args[0])
-			if err != nil {
-				if smtpdetails.IsAlreadyExistsError(err) {
-					exitError(fmt.Sprintf("api key for cluster %s already exists", args[0]), exitCodeErrKnown)
-				}
-				exitError(fmt.Sprintf("unknown error: %v", err), exitCodeErrUnknown)
-			}
-			logger.Debug("smtp details created successfully, converting to secret")
-			smtpSecret := smtpdetails.ConvertSMTPDetailsToSecret(smtpDetails, defaultOutputSecretName)
-			smtpJSON, err := json.MarshalIndent(smtpSecret, "", "    ")
-			if err != nil {
-				exitError(fmt.Sprintf("error converting details to secret: %v", err), exitCodeErrUnknown)
-			}
-			exitSuccess(string(smtpJSON))
-		},
-	}
-
-	cmdGet := &cobra.Command{
-		Use:   "get [cluster id]",
-		Short: "get sendgrid api key id associated with [cluster id]",
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			smtpDetailsClient, err := setupSMTPDetailsClient(logger)
-			if err != nil {
-				exitError("failed to setup smtp details client", exitCodeErrUnknown)
-			}
-			smtpDetails, err := smtpDetailsClient.Get(args[0])
-			if err != nil {
-				if smtpdetails.IsNotExistError(err) {
-					exitError(fmt.Sprintf("api key for cluster %s not found", args[0]), exitCodeErrKnown)
-				}
-				exitError(fmt.Sprintf("unknown error: %v", err), exitCodeErrUnknown)
-			}
-			exitSuccess(smtpDetails.ID)
-		},
-	}
-
-	cmdDelete := &cobra.Command{
-		Use:   "delete [cluster id]",
-		Short: "delete sendgrid sub user and api key associated with [cluster id]",
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			smtpDetailsClient, err := setupSMTPDetailsClient(logger)
-			if err != nil {
-				exitError("failed to setup smtp details client", exitCodeErrUnknown)
-			}
-			if err := smtpDetailsClient.Delete(args[0]); err != nil {
-				if smtpdetails.IsNotExistError(err) {
-					exitError(fmt.Sprintf("api key for cluster %s does not exist", args[0]), exitCodeErrKnown)
-				}
-				exitError(fmt.Sprintf("failed to delete api key %v", err), exitCodeErrUnknown)
-			}
-			exitSuccess("api key deleted")
-		},
-	}
-
-	cmdRefresh := &cobra.Command{
-		Use:   "refresh [cluster id]",
-		Short: "delete api key associated with [cluster id] and genereate a new key",
-		Args:  cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			smtpDetailsClient, err := setupSMTPDetailsClient(logger)
-			if err != nil {
-				exitError("failed to setup smtp details client", exitCodeErrUnknown)
-			}
-			key, err := smtpDetailsClient.Refresh(args[0])
-			if err != nil {
-				if smtpdetails.IsNotExistError(err) {
-					exitError(fmt.Sprintf("cannot create api key for cluster that does not exist, cluster=%s, use the create command", args[0]), exitCodeErrKnown)
-				}
-				exitError(fmt.Sprintf("failed to delete api key %v: ", err), exitCodeErrUnknown)
-			}
-			exitSuccess(key)
-		},
-	}
-
-	cmdVersion := &cobra.Command{
-		Use:   "version",
-		Short: "print the version of the cli",
-		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Print(version.Version)
-		},
-	}
-
-	rootCmd.AddCommand(cmdDelete, cmdGet, cmdCreate, cmdRefresh, cmdVersion)
-	if err := rootCmd.Execute(); err != nil {
-		panic(err)
-	}
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "cli [sub command]",
+	Short: "commands for managing rhmi cluster api keys",
 }
 
 func exitSuccess(message string) {
@@ -154,18 +56,6 @@ func exitError(message string, code int) {
 	os.Exit(code)
 }
 
-func getDebugLevelFromString(levelStr string) logrus.Level {
-	debugMap := map[string]logrus.Level{
-		"verbose": logrus.DebugLevel,
-		"info":    logrus.InfoLevel,
-	}
-	level := debugMap[levelStr]
-	if level == 0 {
-		return logrus.ErrorLevel
-	}
-	return level
-}
-
 func setupSMTPDetailsClient(logger *logrus.Entry) (*sendgrid.Client, error) {
 	smtpdetailsClient, err := sendgrid.NewDefaultClient(logger)
 	if err != nil {
@@ -173,4 +63,28 @@ func setupSMTPDetailsClient(logger *logrus.Entry) (*sendgrid.Client, error) {
 		return nil, errors.Wrap(err, "failed to setup sendgrid smtp details client")
 	}
 	return smtpdetailsClient, nil
+}
+
+func init() {
+	cobra.OnInitialize(func() {
+		if flagDebug {
+			logger.Logger.SetLevel(logrus.DebugLevel)
+		}
+	})
+	// Here you will define your flags and configuration settings.
+	// Cobra supports persistent flags, which, if defined here,
+	// will be global for your application.
+
+	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.main.yaml)")
+
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	rootCmd.PersistentFlags().BoolVar(&flagDebug, "debug", false, "Enable debug output to stderr")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/cmd/cli/refresh.go
+++ b/cmd/cli/refresh.go
@@ -1,0 +1,73 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/integr8ly/smtp-service/pkg/smtpdetails"
+	"github.com/spf13/cobra"
+)
+
+// refreshCmd represents the refresh command
+var refreshCmd = &cobra.Command{
+	Use:   "refresh [cluster id]",
+	Short: "delete api key associated with [cluster id] and genereate a new key",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		smtpDetailsClient, err := setupSMTPDetailsClient(logger)
+		if err != nil {
+			exitError("failed to setup smtp details client", exitCodeErrUnknown)
+		}
+		smtpDetails, err := smtpDetailsClient.Refresh(args[0])
+		if err != nil {
+			if smtpdetails.IsNotExistError(err) {
+				exitError(fmt.Sprintf("cannot create api key for cluster that does not exist, cluster=%s, use the create command", args[0]), exitCodeErrKnown)
+			}
+			exitError(fmt.Sprintf("failed to delete api key %v: ", err), exitCodeErrUnknown)
+		}
+		secretName, err := cmd.Flags().GetString("secret-name")
+		if err != nil {
+			exitError("failed to get secret name flag", exitCodeErrUnknown)
+		}
+		if secretName == "" {
+			logger.Infof("secret name is blank, using default name %s", defaultOutputSecretName)
+			secretName = defaultOutputSecretName
+		}
+		smtpSecret := smtpdetails.ConvertSMTPDetailsToSecret(smtpDetails, secretName)
+		smtpJSON, err := json.MarshalIndent(smtpSecret, "", "    ")
+		if err != nil {
+			exitError(fmt.Sprintf("error converting details to secret: %v", err), exitCodeErrUnknown)
+		}
+		exitSuccess(string(smtpJSON))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(refreshCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// refreshCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// refreshCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	refreshCmd.Flags().StringP("secret-name", "s", defaultOutputSecretName, "Name of the output secret")
+}

--- a/cmd/cli/refresh.go
+++ b/cmd/cli/refresh.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -59,15 +44,5 @@ var refreshCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(refreshCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// refreshCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// refreshCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	refreshCmd.Flags().StringP("secret-name", "s", defaultOutputSecretName, "Name of the output secret")
 }

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,18 +1,3 @@
-/*
-Copyright © 2020 NAME HERE <EMAIL ADDRESS>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package main
 
 import (
@@ -31,14 +16,4 @@ var versionCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2020 NAME HERE <EMAIL ADDRESS>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package main
+
+import (
+	"github.com/integr8ly/smtp-service/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print the version of the cli",
+	Run: func(cmd *cobra.Command, args []string) {
+		exitSuccess(version.Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// versionCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// versionCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/sethvargo/go-password v0.1.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
-	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa // indirect
 	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/pkg/sendgrid/sendgrid_test.go
+++ b/pkg/sendgrid/sendgrid_test.go
@@ -554,7 +554,7 @@ func TestClient_Refresh(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    string
+		want    *smtpdetails.SMTPDetails
 		wantErr bool
 	}{
 		{
@@ -713,6 +713,13 @@ func TestClient_Refresh(t *testing.T) {
 			args: args{
 				id: "",
 			},
+			want: &smtpdetails.SMTPDetails{
+				Host:     "smtp.sendgrid.net",
+				Port:     587,
+				TLS:      true,
+				Username: "apikey",
+				Password: "",
+			},
 		},
 		{
 			name: "key found and deleted, then new key successfully created",
@@ -728,7 +735,7 @@ func TestClient_Refresh(t *testing.T) {
 					}
 					c.GetAPIKeysForSubUserFunc = func(username string) (keys []*APIKey, err error) {
 						return []*APIKey{
-							&APIKey{
+							{
 								ID:     "",
 								Key:    "",
 								Name:   "",
@@ -755,6 +762,13 @@ func TestClient_Refresh(t *testing.T) {
 			args: args{
 				id: "",
 			},
+			want: &smtpdetails.SMTPDetails{
+				Host:     "smtp.sendgrid.net",
+				Port:     587,
+				TLS:      true,
+				Username: "apikey",
+				Password: "",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -770,7 +784,7 @@ func TestClient_Refresh(t *testing.T) {
 				t.Errorf("Refresh() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Refresh() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/sendgrid/sendgridapi.go
+++ b/pkg/sendgrid/sendgridapi.go
@@ -173,7 +173,7 @@ func (c *BackendAPIClient) ListSubUsers(query map[string]string) ([]*SubUser, er
 		query = map[string]string{}
 	}
 	listReq := c.restClient.BuildRequest(APIRouteSubUsers, rest.Get)
-	listReq.QueryParams = query
+	//listReq.QueryParams = query
 	listResp, err := c.restClient.InvokeRequest(listReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list sub users")
@@ -194,8 +194,15 @@ func (c *BackendAPIClient) GetSubUserByUsername(username string) (*SubUser, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list sub users with username %s", username)
 	}
-	if len(subusers) != 1 {
-		return nil, &NotExistError{Message: fmt.Sprintf("should be exactly one sub user with username %s, found %d", username, len(subusers))}
+	var foundUser *SubUser
+	for _, subuser := range subusers {
+		if subuser.Username == username {
+			foundUser = subuser
+			break
+		}
 	}
-	return subusers[0], nil
+	if foundUser == nil {
+		return nil, &NotExistError{Message: fmt.Sprintf("uaer with username %s not found in sendgrid subuser list", username)}
+	}
+	return foundUser, nil
 }

--- a/pkg/sendgrid/sendgridapi.go
+++ b/pkg/sendgrid/sendgridapi.go
@@ -173,7 +173,6 @@ func (c *BackendAPIClient) ListSubUsers(query map[string]string) ([]*SubUser, er
 		query = map[string]string{}
 	}
 	listReq := c.restClient.BuildRequest(APIRouteSubUsers, rest.Get)
-	//listReq.QueryParams = query
 	listResp, err := c.restClient.InvokeRequest(listReq)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to list sub users")

--- a/pkg/sendgrid/sendgridapi.go
+++ b/pkg/sendgrid/sendgridapi.go
@@ -202,7 +202,7 @@ func (c *BackendAPIClient) GetSubUserByUsername(username string) (*SubUser, erro
 		}
 	}
 	if foundUser == nil {
-		return nil, &NotExistError{Message: fmt.Sprintf("uaer with username %s not found in sendgrid subuser list", username)}
+		return nil, &NotExistError{Message: fmt.Sprintf("user with username %s not found in sendgrid subuser list", username)}
 	}
 	return foundUser, nil
 }

--- a/pkg/smtpdetails/smtpdetails.go
+++ b/pkg/smtpdetails/smtpdetails.go
@@ -21,6 +21,7 @@ type SMTPDetails struct {
 type Client interface {
 	Create(id string) (*SMTPDetails, error)
 	Get(id string) (*SMTPDetails, error)
+	Refresh(id string) (*SMTPDetails, error)
 	Delete(id string) error
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	//Version Version of the SMTP Service
-	Version = "0.1.1"
+	Version = "0.2.0"
 )


### PR DESCRIPTION
refactor the cli of the smtp-service to have a structure more
similar to the default cobra generated file structure.

along with this, other changes have been made:
- output a secret on the 'refresh' command
- allow the secret name to be overridden on 'create' and 'refresh'
- change the default output secret name to 'redhat-rhmi-smtp'
- change the debug flow to be a single 'debug' boolean flag

verification:
- for each subcommand: 'create', 'get', 'refresh', 'delete',
  'version', do the following steps
- run the command, ensure it succeeds
- run 'create' and 'refresh' with the 'secret-name' flag set to a
  different string and ensure the output secret name is overridden
- run any command with the 'debug' flag set to 'true' and ensure
  that debug and info logs are shown and they're output to stderr